### PR TITLE
Add FontAwesome support with Icon()

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -35,5 +35,6 @@ exports {
     'Alert',
     'Custom',
     'Image',
-    'Persist'
+    'Persist',
+    'Icon'
 }

--- a/main.lua
+++ b/main.lua
@@ -51,12 +51,17 @@ local function verifyTypes(notiTable, isPersistent)
         return false
     end
 
+    if notiTable.icon and type(notiTable.icon) ~= 'string' then
+        printError('The icon property must be a string for this notifications')
+        return false
+    end
+
     return true
 end
 
 --Triggers a notification in the NUI using supplied params
-local function SendNotification(style, duration, title, message, image, sound, custom, position)
-    DebugPrintInfo(style, duration, title, message, image, sound, custom, position)
+local function SendNotification(style, duration, title, message, image, sound, custom, position, icon)
+    DebugPrintInfo(style, duration, title, message, image, sound, custom, position, icon)
 
     local notiObject = {
         type = 'noti',
@@ -68,6 +73,7 @@ local function SendNotification(style, duration, title, message, image, sound, c
         custom = custom,
         position = position,
         sound = sound,
+        icon = icon,
     }
 
     local areTypesValid = verifyTypes(notiObject)
@@ -141,6 +147,10 @@ function Alert(data)
     SendNotification(data.style, data.duration, nil, data.message, nil, data.sound, data.custom, data.position)
 end
 
+function Icon(data)
+    SendNotification(data.style, data.duration, nil, data.message, nil, data.sound, data.custom, data.position, data.icon)
+end
+
 function Custom(data)
     SendNotification(data.style, data.duration, data.title, data.message, data.image, data.sound, data.custom, data.position)
 end
@@ -164,6 +174,19 @@ AddEventHandler('t-notify:client:Alert', function(data)
         sound = data.sound,
         custom = data.custom,
         position = data.position
+    })
+end)
+
+RegisterNetEvent('t-notify:client:Icon')
+AddEventHandler('t-notify:client:Icon', function(data)
+    Alert({
+        style = data.style,
+        duration = data.duration,
+        message = data.message,
+        sound = data.sound,
+        custom = data.custom,
+        position = data.position,
+        icon = data.icon
     })
 end)
 

--- a/main.lua
+++ b/main.lua
@@ -179,7 +179,7 @@ end)
 
 RegisterNetEvent('t-notify:client:Icon')
 AddEventHandler('t-notify:client:Icon', function(data)
-    Alert({
+    Icon({
         style = data.style,
         duration = data.duration,
         message = data.message,

--- a/nui/SimpleNotification/notification.js
+++ b/nui/SimpleNotification/notification.js
@@ -78,6 +78,7 @@
  * @typedef Content
  * @type {object}
  * @property {string} [image]
+ * @property {string} [icon]
  * @property {string} [text]
  * @property {string} [title]
  * @property {Button[]} [buttons]
@@ -119,6 +120,8 @@ class SimpleNotification {
         this.body = undefined;
         /** @type {HTMLImageElement | undefined} */
         this.image = undefined;
+        /** @type {HTMLElement | undefined} */
+        this.icon = undefined;
         /** @type {string | undefined} */
         this.text = undefined;
         /** @type {HTMLElement | undefined} */
@@ -524,6 +527,26 @@ class SimpleNotification {
     }
 
     /**
+     * Set the icon attribute
+     * @param {string} icon
+     */
+     setIcon(icon) {
+        if (this.ic == undefined) {
+            this.ic = document.createElement('i');
+            if (this.text) {
+                this.body.insertBefore(this.ic, this.text);
+            } else {
+                if (!this.body) {
+                    this.addBody();
+                }
+                this.body.appendChild(this.ic);
+            }
+        }
+        this.ic.className = icon;
+    }
+
+
+    /**
      * Set the image src attribute
      * @param {string} src
      */
@@ -541,6 +564,7 @@ class SimpleNotification {
         }
         this.image.src = src;
     }
+
 
     /**
      * Set the text content of the notification body
@@ -718,6 +742,7 @@ class SimpleNotification {
      */
     static create(classes, content, notificationOptions = {}) {
         let hasImage = 'image' in content && content.image,
+            hasIcon = 'icon' in content && content.icon,
             hasText = 'text' in content && content.text,
             hasTitle = 'title' in content && content.title,
             hasButtons = 'buttons' in content;
@@ -737,6 +762,9 @@ class SimpleNotification {
         }
         if (hasImage) {
             notification.setImage(content.image);
+        }
+        if (hasIcon) {
+            notification.setIcon(content.icon);
         }
         if (hasText) {
             notification.setText(content.text);

--- a/nui/assets/script.js
+++ b/nui/assets/script.js
@@ -17,6 +17,7 @@ const persistentNotis = new Map();
  * @property {string} message - Message
  * @property {string} title - Title of message
  * @property {string} image - Image URL
+ * @property {string} icon - FontAwesome Icon Class
  * @property {boolean} custom - Custom style
  * @property {string} position - Position
  * @property {number} duration - Time in ms
@@ -98,6 +99,7 @@ function playNotification(noti) {
     const content = {
       title: noti.title && noti.title.toString(),
       image: noti.image,
+      icon: noti.icon,
       text: noti.message && noti.message.toString(),
     };
 
@@ -133,6 +135,7 @@ const startPersistentNoti = (id, noti) => {
   const content = {
     title: noti.title,
     image: noti.image,
+    icon: noti.icon,
     text: noti.message,
   };
 
@@ -188,6 +191,10 @@ const updatePersistentNoti = (id, noti) => {
   const persistentNoti = persistentNotis.get(id);
   if (noti.image) {
     persistentNoti.setImage(noti.image)
+  }
+
+  if (noti.icon) {
+    persistentNoti.setIcon(noti.icon)
   }
 
   if (noti.message) {

--- a/nui/main.html
+++ b/nui/main.html
@@ -4,6 +4,7 @@
     <link rel="stylesheet" type="text/css" media="screen" href="./SimpleNotification/notification.css">
     <link rel="stylesheet" href="./assets/styles.css" type="text/css">
     <link rel="stylesheet" href="custom.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js" crossorigin="anonymous"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Pretty self explanatory. I touched a few things to get this to work, there may have been a better way but this way works and I've used it since with no problems.

I also added icon support for Persist and Custom alerts too.

Users can replace the cdn in the html with their own kit if they use fontawesome pro. 