### PR TITLE
feat(persistent): added persist id getter

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,14 +9,14 @@
 * `success`
 * `message`
 
-T-Notify also allows for the addition of custom user-specified classes in the custom.css file that can be used in conjunction with the default styles. 
+T-Notify also allows for the addition of custom user-specified classes in the custom.css file that can be used in conjunction with the default styles.
 
 >By default, there is an example custom notification style included in `/nui/custom.css` that can be used as a reference to build upon. Below you can find a small guide referencing that class.
 
 ## Custom Classes Guide
 
 	/* This snippet is taken from custom.css, in the 'nui' directory */
-	
+
 	/* Always attempt to keep user edited CSS to this file only, unless you know what you are doing  */
 
 	.gn-example {
@@ -25,7 +25,7 @@ T-Notify also allows for the addition of custom user-specified classes in the cu
     	text-shadow: 0 1px 1px white;
 	}
 
->This example above shows a custom style that can be invoked whenever a notification is sent. Custom styles **must** have their CSS class **always** prefixed by `gn-` otherwise they will not work correctly. 
+>This example above shows a custom style that can be invoked whenever a notification is sent. Custom styles **must** have their CSS class **always** prefixed by `gn-` otherwise they will not work correctly.
 
 ### Invoking a Custom Style
 
@@ -74,7 +74,7 @@ Both of them require you pass an **Object**, here are some examples:
 **Client**
 ```lua
 exports['t-notify']:Alert({
-	style = 'error', 
+	style = 'error',
 	message = 'Example alert from the client side'
 })
 ```
@@ -129,7 +129,7 @@ Depending on the function, the object can have optional and required properties.
     * `image` {STRING} (Optional) - Accepts an Image URL to embed into the notification
     * `sound` {BOOL or OBJECT} (Optional) - If true, the notification will also have an alert sound. Can also accept an object for custom sound on a per notification basis. *Defaults to false*.
       * `name` {STRING} (Optional) - An audio name like what can be found in `config.lua`
-      * `reference` {STRING} (Optional) - An audio reference like what can be found in `config.lua` 
+      * `reference` {STRING} (Optional) - An audio reference like what can be found in `config.lua`
     * `custom` {BOOL} (Optional) - This ***must*** be set to true in order to utilize a custom style that wasn't present by default. *Defaults to false*.
     * `position` {STRING} (Optional) - Position of the notification to display (top-left, top-center, top-right, bottom-left, bottom-center, bottom-right, middle-left, middle-right) *Defaults to config value*
 
@@ -277,6 +277,13 @@ exports['t-notify']:Persist({
 })
 ```
 
+*Getting a Persistent Notification:*
+```lua
+-- Client-side
+-- Returns a boolean depending on whether the notification exists or not.
+local exists = exports['t-notify']:IsPersistentShowing('dead')
+```
+
 ## Markdown Formatting Tags
 
 >Notifications allows for *Markdown-like* tags to be used within the `message` property, allowing for easy text styling. Many of these tags can be nested to combine Markdown effects.
@@ -320,8 +327,8 @@ This code snippet produced the following notification:
 | r | Red |
 | g | Green |
 | y | Yellow |
-| b | Blue | 
-| c | Cyan | 
+| b | Blue |
+| c | Cyan |
 | p | Purple |
 | w | White |
 | o | Orange |

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -35,5 +35,6 @@ exports {
     'Alert',
     'Custom',
     'Image',
-    'Persist'
+    'Persist',
+    'IsPersistentShowing'
 }

--- a/main.lua
+++ b/main.lua
@@ -119,8 +119,8 @@ local function SendPersistentNotification(step, id, options)
         while getterActive do
             Wait(5)
         end
+        return getterResult
     end
-    return getterResult
 end
 --Initialize's Config after activated by Thread
 local function InitConfig()

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,4 @@
+local getterActive, getterResult = false, false
 local nuiReady
 
 -- Debug Print Notification
@@ -112,6 +113,14 @@ local function SendPersistentNotification(step, id, options)
             options = options
         })
     end
+
+    if step == 'get' then
+        getterActive = true
+        while getterActive do
+            Wait(5)
+        end
+    end
+    return getterResult
 end
 --Initialize's Config after activated by Thread
 local function InitConfig()
@@ -128,12 +137,18 @@ local function InitConfig()
     SendNUIMessage(initObject)
 end
 
-RegisterNUICallback('nuiReady', function(data, cb)
+RegisterNUICallback('nuiReady', function(_, cb)
     DebugPrint('NUI frame ready')
     nuiReady = true
     -- Send Config File after NUI frame ready
     InitConfig()
-    cb()
+    cb({})
+end)
+
+RegisterNUICallback('persistentGetter', function(data, cb)
+    getterResult = data.exists or false
+    getterActive = false
+    cb({})
 end)
 
 --OBJECT STYLED EXPORTS
@@ -150,7 +165,10 @@ function Image(data)
 end
 
 function Persist(data)
-    SendPersistentNotification(data.step, data.id, data.options)
+    local persist = SendPersistentNotification(data.step, data.id, data.options)
+    if data.step == 'get' then
+        return persist
+    end
 end
 
 --Event Handlers from Server (Objects)

--- a/main.lua
+++ b/main.lua
@@ -1,4 +1,4 @@
-local getterActive, getterResult = false, false
+local PersistentNotiMap = {}
 local nuiReady
 
 -- Debug Print Notification
@@ -105,6 +105,12 @@ local function SendPersistentNotification(step, id, options)
         end
     end
 
+    if step == 'start' then
+        PersistentNotiMap[id] = true
+    elseif step == 'end' then
+        PersistentNotiMap[id] = false
+    end
+
     if areTypesValid then
         SendNUIMessage({
             type = 'persistNoti',
@@ -112,14 +118,6 @@ local function SendPersistentNotification(step, id, options)
             id = id,
             options = options
         })
-    end
-
-    if step == 'get' then
-        getterActive = true
-        while getterActive do
-            Wait(5)
-        end
-        return getterResult
     end
 end
 --Initialize's Config after activated by Thread
@@ -145,12 +143,6 @@ RegisterNUICallback('nuiReady', function(_, cb)
     cb({})
 end)
 
-RegisterNUICallback('persistentGetter', function(data, cb)
-    getterResult = data.exists or false
-    getterActive = false
-    cb({})
-end)
-
 --OBJECT STYLED EXPORTS
 function Alert(data)
     SendNotification(data.style, data.duration, nil, data.message, nil, data.sound, data.custom, data.position)
@@ -165,10 +157,11 @@ function Image(data)
 end
 
 function Persist(data)
-    local persist = SendPersistentNotification(data.step, data.id, data.options)
-    if data.step == 'get' then
-        return persist
-    end
+    SendPersistentNotification(data.step, data.id, data.options)
+end
+
+function IsPersistentShowing(id)
+    return PersistentNotiMap[id] or false
 end
 
 --Event Handlers from Server (Objects)

--- a/nui/assets/script.js
+++ b/nui/assets/script.js
@@ -225,6 +225,12 @@ function playPersistentNoti(noti) {
     case "end":
       endPersistentNoti(id);
       break;
+    case "get":
+      fetch("https://t-notify/persistentGetter", {
+        method: "POST",
+        body: JSON.stringify({exists: persistentNotis.has(id)}),
+      }).catch((e) => console.error(`Unable to get PersistentNoti with id: ${id}.`, e));
+      break;
 
     default:
       console.error(

--- a/nui/assets/script.js
+++ b/nui/assets/script.js
@@ -225,13 +225,6 @@ function playPersistentNoti(noti) {
     case "end":
       endPersistentNoti(id);
       break;
-    case "get":
-      fetch("https://t-notify/persistentGetter", {
-        method: "POST",
-        body: JSON.stringify({exists: persistentNotis.has(id)}),
-      }).catch((e) => console.error(`Unable to get PersistentNoti with id: ${id}.`, e));
-      break;
-
     default:
       console.error(
         "Invalid step for persistent notification must be `start`, `end`, or `update`"


### PR DESCRIPTION
- Added getter for persistent notifications.
- Should also fix the error when fetching NUI by add `{}` to the callbacks.
```lua
RegisterCommand('getter', function(source, args)
    local exists = exports['t-notify']:IsPersistentShowing('dead')
    print(exists)
end)
```